### PR TITLE
Update Video002 fill calculation comments

### DIFF
--- a/Video002/Video002.asm
+++ b/Video002/Video002.asm
@@ -2,8 +2,12 @@
 arch n64.cpu
 endian msb
 output "Video002.N64", create
-// 1024 KB + 4 KB = 1028 KB
+
 fill $0010'1000 // Set ROM Size
+// fill 1052672‬ also works because
+// 4 KB (4096 B) header reserved for config and publisher data
+// 1 MB (1024 KB * 1024 KB = ‭1,048,576‬ B) game code copied to n64 ram on boot
+// 4096 + ‭1048576‬ = 1,052,672‬ B roughly a megabyte used for our game
 
 origin $00000000
 base $80000000

--- a/Video002/Video002.asm
+++ b/Video002/Video002.asm
@@ -8,6 +8,7 @@ fill $0010'1000 // Set ROM Size
 // 4 KB (4096 B) header reserved for config and publisher data
 // 1 MB (1024 KB * 1024 KB = ‭1,048,576‬ B) game code copied to n64 ram on boot
 // 4096 + ‭1048576‬ = 1,052,672‬ B roughly a megabyte used for our game
+// 1052672‬ Bytes is represented as $00101000‬ in hex
 
 origin $00000000
 base $80000000


### PR DESCRIPTION
// 4 KB (4096 B) header has config and publisher data
// 1 MB (1024 KB * 1024 KB = ‭1,048,576‬ B) game code copied to n64 ram on boot

// 4096 + ‭1048576‬ = 1,052,672‬ B roughly a megabyte used for our sample game